### PR TITLE
change `root-dir` to `data-root` + spaces

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ docker_package_state: present
 
 # Docker daemon settings (generates /etc/docker/daemon.json)
 # docker_daemon_settings:
-# root-dir: "/data/"
+#   data-root: "/data/"
 
 # Service options.
 docker_service_state: started


### PR DESCRIPTION
Fix example into default - docker_daemon_settings 
change broken name `root-dir` to correct `data-root`
add spaces before options